### PR TITLE
fix: align message list items across platforms without subject line Fixes #297

### DIFF
--- a/app/src/main/java/com/example/sw0b_001/ui/views/threads/RecentView.kt
+++ b/app/src/main/java/com/example/sw0b_001/ui/views/threads/RecentView.kt
@@ -128,6 +128,8 @@ fun GetMessageAvatar(logo: String?) {
 }
 
 
+
+
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun RecentMessageCard(
@@ -137,9 +139,19 @@ fun RecentMessageCard(
     logo: String? = null,
     onClickCallback: (Payloads) -> Unit,
 ) {
-    var text by remember { mutableStateOf(payload.content.getBody().toUtf8String()) }
-    var heading by remember { mutableStateOf(payload.content.getSubject()?.toUtf8String() ?: "") }
-    var subHeading by remember { mutableStateOf(payload.content.getTo()?.toUtf8String() ?: "" ) }
+    val rawBody = payload.content.getBody().toUtf8String()
+    val heading = payload.content.getSubject()?.toUtf8String() ?: ""
+    val subHeading = payload.content.getTo()?.toUtf8String() ?: ""
+
+    val hasHeading = heading.isNotBlank()
+    val hasSubHeading = subHeading.isNotBlank()
+
+    val maxPreviewChars = 50
+    val previewText = remember(rawBody) {
+        if (rawBody.length > maxPreviewChars) {
+            rawBody.take(maxPreviewChars).trimEnd() + "…"
+        } else rawBody
+    }
 
     Column {
         ListItem(
@@ -152,41 +164,44 @@ fun RecentMessageCard(
                 .fillMaxWidth(),
             headlineContent = {
                 Text(
-                    subHeading,
+                    text = if (hasSubHeading) subHeading else previewText,
                     style = MaterialTheme.typography.bodyMedium,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis
                 )
             },
-            overlineContent = {
-                Text(
-                    heading,
-                    style = if (cat == V1ContentCategories.TEXT) {
-                        MaterialTheme.typography.bodyLarge.copy(fontWeight = FontWeight.Bold)
-                    } else {
-                        MaterialTheme.typography.bodyLarge
-                    },
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis
-                )
-            },
-            supportingContent = {
-                Text(
-                    text = text,
-                    style = MaterialTheme.typography.bodySmall,
-                    maxLines = 2,
-                    overflow = TextOverflow.Ellipsis,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                )
-            },
+            overlineContent = if (hasHeading) {
+                {
+                    Text(
+                        heading,
+                        style = if (cat == V1ContentCategories.TEXT) {
+                            MaterialTheme.typography.bodyLarge.copy(fontWeight = FontWeight.Bold)
+                        } else {
+                            MaterialTheme.typography.bodyLarge
+                        },
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                }
+            } else null,
+            supportingContent = if (hasSubHeading) {
+                {
+                    Text(
+                        text = previewText,
+                        style = MaterialTheme.typography.bodySmall,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+            } else null,
             leadingContent = {
                 GetMessageAvatar(logo)
             },
             trailingContent = {
                 Text(
-//                    text = Helpers.formatDate(LocalContext.current, payload.date),
                     text = date,
                     style = MaterialTheme.typography.labelSmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant
@@ -195,3 +210,5 @@ fun RecentMessageCard(
         )
     }
 }
+
+


### PR DESCRIPTION
Fixes #297

- Message list items (`RecentMessageCard`) now conditionally render `overlineContent` and `supportingContent` only when a subject or recipient exists (Gmail, RelaySMS Mail), instead of always leavingout that layout space.

- Platforms without a subject line (Bluesky, Telegram) now use the message body as the headline content directly, fixing the vertical misalignment between the platform icon and text.

- Added a character-limited, single-line preview for the message body so long messages don't overflow the list item — full message is still viewable by tapping in.

- Testing
Tested on device across Gmail, RelaySMS Mail, Bluesky, and Telegram messages to confirm consistent alignment.


<img width="300" height="600" alt="github" src="https://github.com/user-attachments/assets/a288b840-6c48-40e2-846c-4b8c4c5de439" />




<img width="300" height="600" alt="issues" src="https://github.com/user-attachments/assets/6278c46c-88e4-49c3-a66a-83fa49616b20" />
