### PR TITLE
Redesign settings screen UI with grouped icons and cards

### DIFF
--- a/app/src/main/java/com/example/sw0b_001/ui/modals/AddGatewayClientModal.kt
+++ b/app/src/main/java/com/example/sw0b_001/ui/modals/AddGatewayClientModal.kt
@@ -139,8 +139,8 @@ fun AddGatewayClientModal(
                 horizontalAlignment = Alignment.CenterHorizontally
             ) {
                 Text(
-                    text = if (gatewayClients == null) stringResource(R.string.add_gateway_client) else stringResource(
-                        R.string.edit_gateway_client
+                    text = if (gatewayClients == null) stringResource(R.string.add_routing_numbers) else stringResource(
+                        R.string.edit_routing_numbers
                     ),
                     style = MaterialTheme.typography.headlineSmall,
                     fontWeight = FontWeight.Bold,

--- a/app/src/main/java/com/example/sw0b_001/ui/views/settings/SettingsView.kt
+++ b/app/src/main/java/com/example/sw0b_001/ui/views/settings/SettingsView.kt
@@ -4,6 +4,7 @@ import android.content.res.Configuration
 import android.widget.Toast
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -24,8 +25,7 @@ import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Fingerprint
 import androidx.compose.material.icons.filled.Language
 import androidx.compose.material.icons.filled.Palette
-import androidx.compose.material3.DropdownMenu
-import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
@@ -203,22 +203,29 @@ fun SettingsView(
                             ) {
                                 localeExpanded = true
                             }
-                            DropdownMenu(
-                                expanded = localeExpanded,
-                                onDismissRequest = { localeExpanded = false },
-                                modifier = Modifier
-                                    .clip(RoundedCornerShape(16.dp))
-                                    .background(MaterialTheme.colorScheme.surfaceContainerHigh)
-                            ) {
-                                localeArraysOptions.forEachIndexed { i, item ->
-                                    DropdownMenuItem(
-                                        text = { Text(item) },
-                                        onClick = {
-                                            context.setLocale(localeArraysValues[i])
-                                            localeExpanded = false
+
+                            if (localeExpanded) {
+                                AlertDialog(
+                                    onDismissRequest = { localeExpanded = false },
+                                    title = { Text(stringResource(R.string.language)) },
+                                    text = {
+                                        Column {
+                                            localeArraysOptions.forEachIndexed { i, item ->
+                                                Text(
+                                                    text = item,
+                                                    modifier = Modifier
+                                                        .fillMaxWidth()
+                                                        .clickable {
+                                                            context.setLocale(localeArraysValues[i])
+                                                            localeExpanded = false
+                                                        }
+                                                        .padding(vertical = 12.dp)
+                                                )
+                                            }
                                         }
-                                    )
-                                }
+                                    },
+                                    confirmButton = {}
+                                )
                             }
                         }
                     }
@@ -245,43 +252,46 @@ fun SettingsView(
                 }
             }
 
-            Column(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(start = 8.dp)
-            ) {
-                DropdownMenu(
-                    expanded = themeExpanded,
+            if (themeExpanded) {
+                AlertDialog(
                     onDismissRequest = { themeExpanded = false },
-                    modifier = Modifier
-                        .clip(RoundedCornerShape(16.dp))
-                        .background(MaterialTheme.colorScheme.surfaceContainerHigh)
-                ) {
-                    DropdownMenuItem(
-                        text = { Text(stringResource(com.afkanerd.lib_smsmms_android.R.string.light)) },
-                        onClick = {
-                            AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_NO)
-                            themeExpanded = false
+                    title = { Text(stringResource(com.afkanerd.lib_smsmms_android.R.string.theme)) },
+                    text = {
+                        Column {
+                            Text(
+                                text = stringResource(com.afkanerd.lib_smsmms_android.R.string.light),
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .clickable {
+                                        AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_NO)
+                                        themeExpanded = false
+                                    }
+                                    .padding(vertical = 12.dp)
+                            )
+                            Text(
+                                text = stringResource(com.afkanerd.lib_smsmms_android.R.string.dark),
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .clickable {
+                                        AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_YES)
+                                        themeExpanded = false
+                                    }
+                                    .padding(vertical = 12.dp)
+                            )
+                            Text(
+                                text = stringResource(com.afkanerd.lib_smsmms_android.R.string.system_default),
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .clickable {
+                                        AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM)
+                                        themeExpanded = false
+                                    }
+                                    .padding(vertical = 12.dp)
+                            )
                         }
-                    )
-
-                    DropdownMenuItem(
-                        text = { Text(stringResource(com.afkanerd.lib_smsmms_android.R.string.dark)) },
-                        onClick = {
-                            AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_YES)
-                            themeExpanded = false
-                        }
-                    )
-
-                    DropdownMenuItem(
-                        text = { Text(stringResource(com.afkanerd.lib_smsmms_android.R.string.system_default)) },
-                        onClick = {
-                            AppCompatDelegate
-                                .setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM)
-                            themeExpanded = false
-                        }
-                    )
-                }
+                    },
+                    confirmButton = {}
+                )
             }
 
 //            SettingsItem(

--- a/app/src/main/java/com/example/sw0b_001/ui/views/settings/SettingsView.kt
+++ b/app/src/main/java/com/example/sw0b_001/ui/views/settings/SettingsView.kt
@@ -227,15 +227,15 @@ fun SettingsView(
                 color = MaterialTheme.colorScheme.secondary,
             )
 
-            SettingsItem(
-                itemTitle = stringResource(R.string.send_messages_with_device_id),
-                itemDescription = stringResource(R.string.device_id_lets_you_send_messages_without_using_your_actual_phone_number_for_authentication_this_works_well_for_dual_sim_phones),
-                checked = useDeviceId,
-                enabled = !isEmailLogin && !isLoading,
-            ) {
-                context.settingsSetUseDeviceId(it ?: true)
-                useDeviceId = it ?: true
-            }
+//            SettingsItem(
+//                itemTitle = stringResource(R.string.send_messages_with_device_id),
+//                itemDescription = stringResource(R.string.device_id_lets_you_send_messages_without_using_your_actual_phone_number_for_authentication_this_works_well_for_dual_sim_phones),
+//                checked = useDeviceId,
+//                enabled = !isEmailLogin && !isLoading,
+//            ) {
+//                context.settingsSetUseDeviceId(it ?: true)
+//                useDeviceId = it ?: true
+//            }
 
             Spacer(Modifier.padding(8.dp))
 

--- a/app/src/main/java/com/example/sw0b_001/ui/views/settings/SettingsView.kt
+++ b/app/src/main/java/com/example/sw0b_001/ui/views/settings/SettingsView.kt
@@ -133,7 +133,6 @@ fun SettingsView(
     val scrollState = rememberScrollState()
 
     val isEmailLogin = context.settingsGetIsEmailLogin
-
     var localeExpanded by remember { mutableStateOf(false) }
     var setLockDownApp by remember { mutableStateOf( context.settingsGetLockDownApp) }
     var useDeviceId by remember { mutableStateOf(
@@ -183,7 +182,6 @@ fun SettingsView(
                 LinearProgressIndicator(Modifier.fillMaxWidth())
 
             SectionLabel(stringResource(R.string.system))
-
             Surface(
                 shape = RoundedCornerShape(20.dp),
                 color = Color.Transparent,
@@ -204,6 +202,23 @@ fun SettingsView(
                                 enabled = !isLoading,
                             ) {
                                 localeExpanded = true
+                            }
+                            DropdownMenu(
+                                expanded = localeExpanded,
+                                onDismissRequest = { localeExpanded = false },
+                                modifier = Modifier
+                                    .clip(RoundedCornerShape(16.dp))
+                                    .background(MaterialTheme.colorScheme.surfaceContainerHigh)
+                            ) {
+                                localeArraysOptions.forEachIndexed { i, item ->
+                                    DropdownMenuItem(
+                                        text = { Text(item) },
+                                        onClick = {
+                                            context.setLocale(localeArraysValues[i])
+                                            localeExpanded = false
+                                        }
+                                    )
+                                }
                             }
                         }
                     }
@@ -226,30 +241,6 @@ fun SettingsView(
                                 themeExpanded = true
                             }
                         }
-                    }
-                }
-            }
-
-            Column(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(start = 8.dp)
-            ) {
-                DropdownMenu(
-                    expanded = localeExpanded,
-                    onDismissRequest = { localeExpanded = false },
-                    modifier = Modifier
-                        .clip(RoundedCornerShape(16.dp))
-                        .background(MaterialTheme.colorScheme.surfaceContainerHigh)
-                ) {
-                    localeArraysOptions.forEachIndexed { i, item ->
-                        DropdownMenuItem(
-                            text = { Text(item) },
-                            onClick = {
-                                context.setLocale(localeArraysValues[i])
-                                localeExpanded = false
-                            }
-                        )
                     }
                 }
             }

--- a/app/src/main/java/com/example/sw0b_001/ui/views/settings/SettingsView.kt
+++ b/app/src/main/java/com/example/sw0b_001/ui/views/settings/SettingsView.kt
@@ -1,23 +1,29 @@
 package com.example.sw0b_001.ui.views.settings
 
-
-import android.content.Context
-import android.content.ContextWrapper
 import android.content.res.Configuration
 import android.widget.Toast
-import androidx.activity.ComponentActivity
-import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.app.AppCompatDelegate
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.LinearProgressIndicator
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Fingerprint
+import androidx.compose.material.icons.filled.Language
+import androidx.compose.material.icons.filled.Palette
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -26,28 +32,29 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.res.stringArrayResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.navigation.NavController
-import androidx.navigation.compose.rememberNavController
-import com.afkanerd.smswithoutborders_libsmsmms.extensions.context.getActivity
 import com.afkanerd.smswithoutborders_libsmsmms.extensions.context.getCurrentLocale
 import com.afkanerd.smswithoutborders_libsmsmms.extensions.context.setLocale
 import com.afkanerd.smswithoutborders_libsmsmms.ui.SettingsItem
@@ -63,13 +70,56 @@ import com.example.sw0b_001.extensions.context.settingsGetStoreTokensOnDevice
 import com.example.sw0b_001.extensions.context.settingsGetUseDeviceId
 import com.example.sw0b_001.extensions.context.settingsSetIsLoggedIn
 import com.example.sw0b_001.extensions.context.settingsSetLockDownApp
-import com.example.sw0b_001.extensions.context.settingsSetUseDeviceId
-import com.example.sw0b_001.ui.theme.AppTheme
 import com.example.sw0b_001.ui.viewModels.TokensViewModel
 import io.grpc.StatusRuntimeException
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+
+@Composable
+private fun SectionLabel(text: String) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = Modifier.padding(start = 20.dp, top = 20.dp, bottom = 8.dp)
+    ) {
+        Box(
+            modifier = Modifier
+                .size(6.dp)
+                .clip(CircleShape)
+                .background(MaterialTheme.colorScheme.primary)
+        )
+        Spacer(modifier = Modifier.width(8.dp))
+        Text(
+            text = text.uppercase(),
+            style = MaterialTheme.typography.labelMedium.copy(
+                fontWeight = FontWeight.SemiBold,
+                letterSpacing = 1.2.sp
+            ),
+            color = MaterialTheme.colorScheme.primary
+        )
+    }
+}
+
+@Composable
+private fun RowIcon(
+    icon: androidx.compose.ui.graphics.vector.ImageVector,
+    tint: Color = MaterialTheme.colorScheme.onSurfaceVariant,
+    background: Color = MaterialTheme.colorScheme.surfaceContainerHighest
+) {
+    Box(
+        modifier = Modifier
+            .size(40.dp)
+            .clip(CircleShape)
+            .background(background),
+        contentAlignment = Alignment.Center
+    ) {
+        Icon(
+            imageVector = icon,
+            contentDescription = null,
+            tint = tint,
+            modifier = Modifier.size(20.dp)
+        )
+    }
+}
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -97,7 +147,6 @@ fun SettingsView(
 
     var isLoading by remember { mutableStateOf(false) }
 
-
     val localeArraysValues = stringArrayResource(R.array.language_values)
     val localeArraysOptions= stringArrayResource(R.array.language_options)
 
@@ -115,7 +164,12 @@ fun SettingsView(
                     }
                 },
                 title = {
-                    Text(stringResource(R.string.general_settings))
+                    Text(
+                        stringResource(R.string.general_settings),
+                        style = MaterialTheme.typography.titleLarge.copy(
+                            fontWeight = FontWeight.Bold
+                        )
+                    )
                 },
                 colors = TopAppBarDefaults.topAppBarColors()
             )
@@ -128,22 +182,52 @@ fun SettingsView(
             if(isLoading || inPreviewMode)
                 LinearProgressIndicator(Modifier.fillMaxWidth())
 
-            Spacer(modifier = Modifier.height(4.dp))
-            Text(
-                stringResource(R.string.system),
-                fontSize = 13.sp,
-                modifier = Modifier.padding(start = 10.dp),
-                style = MaterialTheme.typography.labelSmall,
-                color = MaterialTheme.colorScheme.secondary,
-            )
-            SettingsItem(
-                itemTitle = stringResource(R.string.language),
-                itemDescription = context.getCurrentLocale()?.displayName ?:
-                stringResource(R.string.english1),
-                checked = null,
-                enabled = !isLoading,
+            SectionLabel(stringResource(R.string.system))
+
+            Surface(
+                shape = RoundedCornerShape(20.dp),
+                color = Color.Transparent,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp)
             ) {
-                localeExpanded = true
+                Column {
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        Spacer(modifier = Modifier.width(12.dp))
+                        RowIcon(icon = Icons.Filled.Language)
+                        Box(modifier = Modifier.weight(1f)) {
+                            SettingsItem(
+                                itemTitle = stringResource(R.string.language),
+                                itemDescription = context.getCurrentLocale()?.displayName ?:
+                                stringResource(R.string.english1),
+                                checked = null,
+                                enabled = !isLoading,
+                            ) {
+                                localeExpanded = true
+                            }
+                        }
+                    }
+
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        Spacer(modifier = Modifier.width(12.dp))
+                        RowIcon(icon = Icons.Filled.Palette)
+                        Box(modifier = Modifier.weight(1f)) {
+                            SettingsItem(
+                                itemTitle = stringResource(com.afkanerd.lib_smsmms_android.R.string.theme),
+                                itemDescription = when(currentNightMode) {
+                                    Configuration.UI_MODE_NIGHT_YES -> stringResource(com.afkanerd.lib_smsmms_android.R.string.dark)
+                                    Configuration.UI_MODE_NIGHT_NO -> stringResource(com.afkanerd.lib_smsmms_android.R.string.light)
+                                    else -> stringResource(com.afkanerd.lib_smsmms_android.R.string.system_default)
+                                },
+                                checked = null,
+                                enabled = !isLoading,
+                                horizontalDivide = false
+                            ) {
+                                themeExpanded = true
+                            }
+                        }
+                    }
+                }
             }
 
             Column(
@@ -153,7 +237,10 @@ fun SettingsView(
             ) {
                 DropdownMenu(
                     expanded = localeExpanded,
-                    onDismissRequest = { localeExpanded = false }
+                    onDismissRequest = { localeExpanded = false },
+                    modifier = Modifier
+                        .clip(RoundedCornerShape(16.dp))
+                        .background(MaterialTheme.colorScheme.surfaceContainerHigh)
                 ) {
                     localeArraysOptions.forEachIndexed { i, item ->
                         DropdownMenuItem(
@@ -167,19 +254,6 @@ fun SettingsView(
                 }
             }
 
-            SettingsItem(
-                itemTitle = stringResource(com.afkanerd.lib_smsmms_android.R.string.theme),
-                itemDescription = when(currentNightMode) {
-                    Configuration.UI_MODE_NIGHT_YES -> stringResource(com.afkanerd.lib_smsmms_android.R.string.dark)
-                    Configuration.UI_MODE_NIGHT_NO -> stringResource(com.afkanerd.lib_smsmms_android.R.string.light)
-                    else -> stringResource(com.afkanerd.lib_smsmms_android.R.string.system_default)
-                },
-                checked = null,
-                enabled = !isLoading,
-            ) {
-                themeExpanded = true
-            }
-
             Column(
                 modifier = Modifier
                     .fillMaxWidth()
@@ -187,7 +261,10 @@ fun SettingsView(
             ) {
                 DropdownMenu(
                     expanded = themeExpanded,
-                    onDismissRequest = { themeExpanded = false }
+                    onDismissRequest = { themeExpanded = false },
+                    modifier = Modifier
+                        .clip(RoundedCornerShape(16.dp))
+                        .background(MaterialTheme.colorScheme.surfaceContainerHigh)
                 ) {
                     DropdownMenuItem(
                         text = { Text(stringResource(com.afkanerd.lib_smsmms_android.R.string.light)) },
@@ -216,17 +293,6 @@ fun SettingsView(
                 }
             }
 
-//            HorizontalDivider(Modifier.padding(8.dp))
-
-            Spacer(Modifier.padding(8.dp))
-            Text(
-                stringResource(R.string.publishing),
-                fontSize = 13.sp,
-                modifier = Modifier.padding(start = 12.dp),
-                style = MaterialTheme.typography.labelSmall,
-                color = MaterialTheme.colorScheme.secondary,
-            )
-
 //            SettingsItem(
 //                itemTitle = stringResource(R.string.send_messages_with_device_id),
 //                itemDescription = stringResource(R.string.device_id_lets_you_send_messages_without_using_your_actual_phone_number_for_authentication_this_works_well_for_dual_sim_phones),
@@ -237,73 +303,103 @@ fun SettingsView(
 //                useDeviceId = it ?: true
 //            }
 
-            Spacer(Modifier.padding(8.dp))
+            SectionLabel(stringResource(R.string.security))
 
-            Text(
-                stringResource(R.string.security),
-                fontSize = 13.sp,
-                modifier = Modifier.padding(start = 12.dp),
-                style = MaterialTheme.typography.labelSmall,
-                color = MaterialTheme.colorScheme.secondary,
-            )
-
-            SettingsItem(
-                itemTitle = stringResource(R.string.lock_app),
-                itemDescription = stringResource(R.string.this_will_lock_the_app_using_your_phone_s_biometric_security_configurations_you_will_need_to_globally_set_for_the_device),
-                checked = setLockDownApp,
-                enabled = !isLoading,
-                horizontalDivide = false
-            ) { checked ->
-                context.promptBiometrics(context.getAppCompatActivity()!!) {
-                    if(it) {
-                        context.settingsSetLockDownApp(checked!!)
-                        setLockDownApp = checked
-                    }
-                    else {
-                        scope.launch(Dispatchers.Default) {
-                            Toast.makeText(context,
-                                context.getString(R.string.failed_to_set_biometric_authentication),
-                                Toast.LENGTH_LONG).show()
-                        }
-                    }
-                }
-            }
-
-            SettingsItem(
-                itemTitle = stringResource(R.string.delete_account),
-                itemDescription = stringResource(R.string.this_would_revoke_all_your_stored_tokens_security_keys_and_every_data_you_have_stored_on_device_and_vault_you_can_still_use_bridges_whenever_you_prefer),
-                isWarning = true,
-                enabled = !isLoading,
+            Surface(
+                shape = RoundedCornerShape(20.dp),
+                color = Color.Transparent,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp)
             ) {
-                isLoading = true
-                scope.launch(Dispatchers.Default) {
-                    context.settingsSetIsLoggedIn(false)
-                    try {
-                        TODO("Remove from cloud")
-                        tokensViewModel.reset {
-                            navController.popBackStack()
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Spacer(modifier = Modifier.width(12.dp))
+                    RowIcon(icon = Icons.Filled.Fingerprint)
+                    Box(modifier = Modifier.weight(1f)) {
+                        SettingsItem(
+                            itemTitle = stringResource(R.string.lock_app),
+                            itemDescription = stringResource(R.string.this_will_lock_the_app_using_your_phone_s_biometric_security_configurations_you_will_need_to_globally_set_for_the_device),
+                            checked = setLockDownApp,
+                            enabled = !isLoading,
+                            horizontalDivide = false
+                        ) { checked ->
+                            context.promptBiometrics(context.getAppCompatActivity()!!) {
+                                if(it) {
+                                    context.settingsSetLockDownApp(checked!!)
+                                    setLockDownApp = checked
+                                }
+                                else {
+                                    scope.launch(Dispatchers.Default) {
+                                        Toast.makeText(context,
+                                            context.getString(R.string.failed_to_set_biometric_authentication),
+                                            Toast.LENGTH_LONG).show()
+                                    }
+                                }
+                            }
                         }
-                    } catch(e: StatusRuntimeException) {
-                        e.printStackTrace()
-                        scope.launch(Dispatchers.Main){
-                            Toast.makeText(context, e.status.description,
-                                Toast.LENGTH_SHORT)
-                                .show()
-                        }
-                    } catch(e: Exception) {
-                        e.printStackTrace()
-                        scope.launch(Dispatchers.Main){
-                            Toast.makeText(context, e.message,
-                                Toast.LENGTH_SHORT).show()
-                        }
-                    } finally {
-                        isLoading = false
                     }
                 }
             }
+
+            SectionLabel(stringResource(R.string.account))
+
+            Surface(
+                shape = RoundedCornerShape(20.dp),
+                color = MaterialTheme.colorScheme.error,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp)
+                    .clip(RoundedCornerShape(20.dp))
+            ) {
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Spacer(modifier = Modifier.width(12.dp))
+                    RowIcon(
+                        icon = Icons.Filled.Delete,
+                        tint = MaterialTheme.colorScheme.error,
+                        background = Color.White
+                    )
+                    Box(modifier = Modifier.weight(1f)) {
+                        SettingsItem(
+                            itemTitle = stringResource(R.string.delete_account),
+                            itemDescription = stringResource(R.string.this_would_revoke_all_your_stored_tokens_security_keys_and_every_data_you_have_stored_on_device_and_vault_you_can_still_use_bridges_whenever_you_prefer),
+                            isWarning = true,
+                            enabled = !isLoading,
+                        ) {
+                            isLoading = true
+                            scope.launch(Dispatchers.Default) {
+                                context.settingsSetIsLoggedIn(false)
+                                try {
+                                    TODO("Remove from cloud")
+                                    tokensViewModel.reset {
+                                        navController.popBackStack()
+                                    }
+                                } catch(e: StatusRuntimeException) {
+                                    e.printStackTrace()
+                                    scope.launch(Dispatchers.Main){
+                                        Toast.makeText(context, e.status.description,
+                                            Toast.LENGTH_SHORT)
+                                            .show()
+                                    }
+                                } catch(e: Exception) {
+                                    e.printStackTrace()
+                                    scope.launch(Dispatchers.Main){
+                                        Toast.makeText(context, e.message,
+                                            Toast.LENGTH_SHORT).show()
+                                    }
+                                } finally {
+                                    isLoading = false
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            Spacer(modifier = Modifier.height(24.dp))
 
             if(BuildConfig.DEBUG) {
-                HorizontalDivider(Modifier.padding(top = 20.dp))
+                HorizontalDivider(Modifier.padding(horizontal = 16.dp))
+                Spacer(modifier = Modifier.height(4.dp))
                 SettingsItem(
                     itemTitle = "Export logs",
                     itemDescription = "Export crash logs for debugging purposes",
@@ -312,6 +408,8 @@ fun SettingsView(
                     CrashHandler.offerCrashLogOptions(activity, context)
                 }
             }
+
+            Spacer(modifier = Modifier.height(24.dp))
         }
     }
 }

--- a/app/src/main/java/com/example/sw0b_001/ui/views/tabs/GatewayClientsView.kt
+++ b/app/src/main/java/com/example/sw0b_001/ui/views/tabs/GatewayClientsView.kt
@@ -207,7 +207,7 @@ fun GatewayClientCard(
 
                 IconButton(onClick = editCallback ) {
                     Icon(Icons.Default.ModeEdit,
-                        stringResource(R.string.edit_gateway_client)
+                        stringResource(R.string.edit_routing_numbers)
                     )
                 }
 

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -84,7 +84,6 @@
     <string name="settings">الإعدادات</string>
     <string name="permission_denied">تم رفض الإذن!</string>
     <string name="add_gateway_client">إضافة عميل البوابة</string>
-    <string name="edit_gateway_client">تحرير عميل البوابة</string>
     <string name="e_g_237123456_or_select_contact">على سبيل المثال +237123456 أو حدد جهة اتصال</string>
     <string name="alias_optional">الاسم المستعار (اختياري)</string>
     <string name="name_to_help_remember_the_gateway_client">اسم للمساعدة في تذكر عميل البوابة</string>
@@ -100,6 +99,7 @@
     <string name="add_account">إضافة حساب</string>
     <string name="remove_accounts">إزالة الحسابات</string>
     <string name="adding_emails_to_your_relaysms_account_enables_you_use_them_to_send_emails_using_sms_messaging_gmail_are_currently_supported">تتيح لك إضافة رسائل بريد إلكتروني إلى حساب RelaySMS الخاص بك استخدامها لإرسال رسائل بريد إلكتروني باستخدام رسائل SMS.\n\nGmail مدعوم حاليًا.</string>
+    <string name="adding_emails_to_your_relaysms_account_enables_you_use_them_to_send_emails_using_sms_messaging__are_currently_supported">تتيح لك إضافة عناوين البريد الإلكتروني إلى حساب RelaySMS الخاص بك استخدامها لإرسال رسائل البريد الإلكتروني باستخدام الرسائل النصية القصيرة (SMS).</string>
     <string name="adding_numbers_to_your_relaysms_account_enables_you_use_them_to_send_messages_using_sms_messaging_telegram_messaging_is_currently_supported">تتيح لك إضافة أرقام إلى حساب RelaySMS الخاص بك استخدامها لإرسال رسائل باستخدام رسائل SMS.\n\nمراسلة Telegram مدعومة حاليًا.</string>
     <string name="adding_accounts_to_your_relaysms_account_enables_you_use_them_to_make_post_using_sms_messaging_posting_is_currently_supported">تتيح لك إضافة حسابات إلى حساب RelaySMS الخاص بك استخدامها لإنشاء منشور باستخدام رسائل SMS.\n\nالنشر مدعوم حاليًا.</string>
     <string name="your_relaysms_account_is_an_alias_of_your_phone_number_with_the_domain_relaysms_me_you_can_receive_replies_by_sms_whenever_a_message_is_sent_to_your_alias">حساب RelaySMS الخاص بك هو اسم مستعار لرقم هاتفك مع النطاق @relaysms.me.\n\nيمكنك تلقي الردود عبر الرسائل القصيرة عندما يتم إرسال رسالة إلى اسمك المستعار.</string>
@@ -135,6 +135,7 @@
     <string name="create_your_account_and">إنشاء حسابك و</string>
     <string name="save_platforms">حفظ المنصات</string>
     <string name="for_relaysms_to_send_messages_to_gmail_x_and_telegram_on_your_behalf_when_offline">لـ RelaySMS لإرسال رسائل إلى Gmail و X و Telegram نيابة عنك عندما تكون غير متصل بالإنترنت</string>
+    <string name="for_relaysms_to_send_messages_to__x_and_telegram_on_your_behalf_when_offline">لتمكين RelaySMS من إرسال الرسائل إلى Gmail وX وTelegram نيابةً عنك عند عدم الاتصال بالإنترنت</string>
     <string name="i_have_read_the">لقد قرأت</string>
     <string name="privacy_policy">سياسةالخصوصية</string>
     <string name="log_in">تسجيل الدخول</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -82,7 +82,6 @@
     <string name="settings">Einstellungen</string>
     <string name="permission_denied">Berechtigung verweigert!</string>
     <string name="add_gateway_client">Gateway-Client hinzufügen</string>
-    <string name="edit_gateway_client">Gateway-Client bearbeiten</string>
     <string name="e_g_237123456_or_select_contact">z. B. +237123456 oder Kontakt auswählen</string>
     <string name="alias_optional">Alias (optional)</string>
     <string name="name_to_help_remember_the_gateway_client">Name zur Erinnerung an den Gateway-Client</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -83,7 +83,6 @@
     <string name="settings">Configuración</string>
     <string name="permission_denied">¡Permiso denegado!</string>
     <string name="add_gateway_client">Agregar cliente de puerta de enlace</string>
-    <string name="edit_gateway_client">Editar cliente de puerta de enlace</string>
     <string name="e_g_237123456_or_select_contact">p. ej. +237123456 o seleccionar contacto</string>
     <string name="alias_optional">Alias (opcional)</string>
     <string name="name_to_help_remember_the_gateway_client">Nombre para ayudar a recordar el cliente de la puerta de enlace</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -83,7 +83,6 @@
     <string name="settings">تنظیمات</string>
     <string name="permission_denied">مجوز رد شد!</string>
     <string name="add_gateway_client">افزودن مشتری دروازه</string>
-    <string name="edit_gateway_client">ویرایش مشتری دروازه</string>
     <string name="e_g_237123456_or_select_contact">به عنوان مثال +237123456 یا انتخاب مخاطب</string>
     <string name="alias_optional">نام مستعار (اختیاری)</string>
     <string name="name_to_help_remember_the_gateway_client">نام برای کمک به یادآوری مشتری دروازه</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -83,8 +83,7 @@
     <string name="settings">Paramètres</string>
     <string name="permission_denied">Autorisation refusée !</string>
     <string name="add_gateway_client">Ajouter un client de passerelle</string>
-    <string name="add_routing_numbers">Ajouter les numéros de routage</string>
-    <string name="edit_gateway_client">Modifier le client de la passerelle</string>
+    <string name="edit_routing_numbers">Modifier les numéros de routage</string>
     <string name="e_g_237123456_or_select_contact">par ex. +237123456 ou sélectionner un contact</string>
     <string name="alias_optional">Alias (facultatif)</string>
     <string name="name_to_help_remember_the_gateway_client">Nom pour aider à se souvenir du client de la passerelle</string>
@@ -482,4 +481,5 @@
     <string name="always_available_no_setup_required">Toujours disponible - Aucune installation requise.</string>
     <string name="this_lets_the_app_manage_the_sending_requirements_for_you">Cela permet à l\'application de gérer les exigences d\'envoi pour vous.</string>
     <string name="onboarding_save_vault_description">Enregistrez l\'accès à vos comptes. Il est stocké en toute sécurité sur votre appareil, vous permettant ainsi d\'envoyer des messages en votre nom propre.</string>
+    <string name="add_routing_numbers">Ajouter les numéros de routage</string>
 </resources>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -86,7 +86,6 @@
     <string name="settings">सेटिंग्स</string>
     <string name="permission_denied">अनुमति अस्वीकृत!</string>
     <string name="add_gateway_client">गेटवे क्लाइंट जोड़ें</string>
-    <string name="edit_gateway_client">गेटवे क्लाइंट संपादित करें</string>
     <string name="e_g_237123456_or_select_contact">जैसे +237123456 या संपर्क चुनें</string>
     <string name="alias_optional">उपनाम (वैकल्पिक)</string>
     <string name="name_to_help_remember_the_gateway_client">गेटवे क्लाइंट को याद रखने में मदद करने के लिए नाम</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -85,7 +85,6 @@
     <string name="settings">설정</string>
     <string name="permission_denied">권한이 거부되었습니다!</string>
     <string name="add_gateway_client">게이트웨이 클라이언트 추가</string>
-    <string name="edit_gateway_client">게이트웨이 클라이언트 편집</string>
     <string name="e_g_237123456_or_select_contact">예: +237123456 또는 연락처 선택</string>
     <string name="alias_optional">별칭 (선택 사항)</string>
     <string name="name_to_help_remember_the_gateway_client">게이트웨이 클라이언트를 기억하는 데 도움이 되는 이름</string>

--- a/app/src/main/res/values-sn/strings.xml
+++ b/app/src/main/res/values-sn/strings.xml
@@ -121,7 +121,8 @@
     <string name="countries">Nyika</string>
     <string name="settings">Zvirongwa</string>
     <string name="permission_denied">Mvumo Yarambwa!</string>
-    <string name="add_gateway_client">Wedzera Mushandisi weGedhi</string> <string name="edit_gateway_client">Gadzirisa Mushandisi weGedhi</string> <string name="e_g_237123456_or_select_contact">sekuti +237123456 kana sarudza waunotumira</string>
+    <string name="add_gateway_client">Wedzera Mushandisi weGedhi</string>
+    <string name="e_g_237123456_or_select_contact">sekuti +237123456 kana sarudza waunotumira</string>
     <string name="alias_optional">Zita rekunyepedzera (zvisiri zvekumanikidza)</string>
     <string name="name_to_help_remember_the_gateway_client">Zita rekubatsira kuyeuka Mushandisi weGedhi</string> <string name="saving">Kuchengeta…</string>
     <string name="save">Chengeta</string>

--- a/app/src/main/res/values-sw/strings.xml
+++ b/app/src/main/res/values-sw/strings.xml
@@ -83,7 +83,6 @@
     <string name="settings">Mipangilio</string>
     <string name="permission_denied">Ruhusa Imekataliwa!</string>
     <string name="add_gateway_client">Ongeza Mteja wa Lango</string>
-    <string name="edit_gateway_client">Hariri Mteja wa Lango</string>
     <string name="e_g_237123456_or_select_contact">mf. +237123456 au chagua anwani</string>
     <string name="alias_optional">Jina bandia (hiari)</string>
     <string name="name_to_help_remember_the_gateway_client">Jina la kusaidia kukumbuka Mteja wa Lango</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -83,7 +83,6 @@
     <string name="settings">Ayarlar</string>
     <string name="permission_denied">İzin Reddedildi!</string>
     <string name="add_gateway_client">Ağ Geçidi İstemcisi Ekle</string>
-    <string name="edit_gateway_client">Ağ Geçidi İstemcisini Düzenle</string>
     <string name="e_g_237123456_or_select_contact">örn. +237123456 veya bir kişi seçin</string>
     <string name="alias_optional">Takma ad (isteğe bağlı)</string>
     <string name="name_to_help_remember_the_gateway_client">Ağ Geçidi İstemcisini hatırlamaya yardımcı olacak ad</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -86,7 +86,6 @@
     <string name="settings">设置</string>
     <string name="permission_denied">权限被拒绝！</string>
     <string name="add_gateway_client">添加网关客户端</string>
-    <string name="edit_gateway_client">编辑网关客户端</string>
     <string name="e_g_237123456_or_select_contact">例如 +237123456 或选择联系人</string>
     <string name="alias_optional">别名 (可选)</string>
     <string name="name_to_help_remember_the_gateway_client">用于帮助记住网关客户端的名称</string>
@@ -102,6 +101,7 @@
     <string name="add_account">添加帐户</string>
     <string name="remove_accounts">移除帐户</string>
     <string name="adding_emails_to_your_relaysms_account_enables_you_use_them_to_send_emails_using_sms_messaging_gmail_are_currently_supported">将电子邮件添加到您的 RelaySMS 帐户后，您可以使用它们通过短信发送电子邮件。\n\n目前支持 Gmail。</string>
+    <string name="adding_emails_to_your_relaysms_account_enables_you_use_them_to_send_emails_using_sms_messaging__are_currently_supported">将电子邮件地址添加到您的 RelaySMS 帐户后，您就可以使用短信功能发送电子邮件。</string>
     <string name="adding_numbers_to_your_relaysms_account_enables_you_use_them_to_send_messages_using_sms_messaging_telegram_messaging_is_currently_supported">将号码添加到您的 RelaySMS 帐户后，您可以使用它们通过短信发送消息。\n\n目前支持 Telegram 消息。</string>
     <string name="adding_accounts_to_your_relaysms_account_enables_you_use_them_to_make_post_using_sms_messaging_posting_is_currently_supported">将帐户添加到您的 RelaySMS 帐户后，您可以使用它们通过短信发帖。\n\n目前支持发帖功能。</string>
     <string name="your_relaysms_account_is_an_alias_of_your_phone_number_with_the_domain_relaysms_me_you_can_receive_replies_by_sms_whenever_a_message_is_sent_to_your_alias">您的 RelaySMS 帐户是您电话号码的别名，域名为 @relaysms.me。\n\n当消息发送到您的别名时，您可以通过短信接收回复。</string>
@@ -137,6 +137,7 @@
     <string name="create_your_account_and">创建您的帐户并</string>
     <string name="save_platforms">保存平台</string>
     <string name="for_relaysms_to_send_messages_to_gmail_x_and_telegram_on_your_behalf_when_offline">以便 RelaySMS 在您离线时代表您向 Gmail、X 和 Telegram 发送消息</string>
+    <string name="for_relaysms_to_send_messages_to__x_and_telegram_on_your_behalf_when_offline">离线时，RelaySMS 可以代表您向 Gmail、X 和 Telegram 发送消息。</string>
     <string name="i_have_read_the">我已阅读</string>
     <string name="privacy_policy">隐私政策</string>
     <string name="log_in">登录</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -104,7 +104,7 @@
     <string name="lock_screen_relay_sms_is_locked">RelaySMS App is locked</string>
     <string name="lock_screen_unlock_with_your_phone_s_locking_system">Unlock with your phone\'s locking system</string>
     <string name="gateway_client_add_custom_example_text">e.g +237123456789 or select contact</string>
-    <string name="gateway_client_add_gateway_client_text">Add Gateway Client</string>
+    <string name="gateway_client_add_gateway_client_text">Add Gateway Client text</string>
     <string name="otp_verification_code_template" translatable="false">Your SMSWithoutBorders-Auth verification code is: </string>
 
     <string name="logout_you_have_no_accounts_logged_into_vaults_at_this_time">You have no accounts logged into Vaults at this time</string>
@@ -136,8 +136,7 @@
     <string name="countries">Countries</string>
     <string name="settings">Settings</string>
     <string name="permission_denied">Permission Denied!</string>
-    <string name="add_gateway_client">Add Gateway Client</string>
-    <string name="edit_gateway_client">Edit Gateway Client</string>
+    <string name="edit_routing_numbers">Edit Routing Numbers</string>
     <string name="e_g_237123456_or_select_contact">e.g +237123456 or select contact</string>
     <string name="alias_optional">Alias (optional)</string>
     <string name="name_to_help_remember_the_gateway_client">Name to help remember the Gateway Client</string>
@@ -547,5 +546,6 @@
     <string name="when_adding_accounts_for_platforms_that_utilize_oauth2_0_e_g_gmail_x_enabling_this_makes_sure_your_access_tokens_are_rather_stored_on_your_current_device">When adding accounts for platforms that use OAuth2.0 (e.g., Gmail, X), enabling this option ensures that your access tokens are stored on your current device instead.</string>
     <string name="onboarding_save_vault_description">Save access to your accounts. It\'s stored securely on your device, so you can send messages as yourself.</string>
     <string name="add_gateway_client">Add a gateway client</string>
+    <string name="add_routing_numbers">Add Routing Numbers</string>
 
 </resources>

--- a/diff_output.txt
+++ b/diff_output.txt
@@ -1,0 +1,455 @@
+diff --git a/app/src/main/java/com/example/sw0b_001/ui/views/settings/SettingsView.kt b/app/src/main/java/com/example/sw0b_001/ui/views/settings/SettingsView.kt
+index 6ae9926f..ecfb767a 100644
+--- a/app/src/main/java/com/example/sw0b_001/ui/views/settings/SettingsView.kt
++++ b/app/src/main/java/com/example/sw0b_001/ui/views/settings/SettingsView.kt
+@@ -1,23 +1,29 @@
+ package com.example.sw0b_001.ui.views.settings
+ 
+-
+-import android.content.Context
+-import android.content.ContextWrapper
+ import android.content.res.Configuration
+ import android.widget.Toast
+-import androidx.activity.ComponentActivity
+-import androidx.appcompat.app.AppCompatActivity
+ import androidx.appcompat.app.AppCompatDelegate
++import androidx.compose.foundation.background
++import androidx.compose.foundation.layout.Box
+ import androidx.compose.foundation.layout.Column
++import androidx.compose.foundation.layout.Row
+ import androidx.compose.foundation.layout.Spacer
+ import androidx.compose.foundation.layout.fillMaxWidth
+ import androidx.compose.foundation.layout.height
+ import androidx.compose.foundation.layout.padding
++import androidx.compose.foundation.layout.size
++import androidx.compose.foundation.layout.width
+ import androidx.compose.foundation.rememberScrollState
++import androidx.compose.foundation.shape.CircleShape
++import androidx.compose.foundation.shape.RoundedCornerShape
+ import androidx.compose.foundation.verticalScroll
+ import androidx.compose.material.LinearProgressIndicator
+ import androidx.compose.material.icons.Icons
+ import androidx.compose.material.icons.automirrored.filled.ArrowBack
++import androidx.compose.material.icons.filled.Delete
++import androidx.compose.material.icons.filled.Fingerprint
++import androidx.compose.material.icons.filled.Language
++import androidx.compose.material.icons.filled.Palette
+ import androidx.compose.material3.DropdownMenu
+ import androidx.compose.material3.DropdownMenuItem
+ import androidx.compose.material3.ExperimentalMaterial3Api
+@@ -26,28 +32,29 @@ import androidx.compose.material3.Icon
+ import androidx.compose.material3.IconButton
+ import androidx.compose.material3.MaterialTheme
+ import androidx.compose.material3.Scaffold
++import androidx.compose.material3.Surface
+ import androidx.compose.material3.Text
+ import androidx.compose.material3.TopAppBar
+ import androidx.compose.material3.TopAppBarDefaults
+ import androidx.compose.runtime.Composable
+-import androidx.compose.runtime.collectAsState
+ import androidx.compose.runtime.getValue
+ import androidx.compose.runtime.mutableStateOf
+ import androidx.compose.runtime.remember
+ import androidx.compose.runtime.rememberCoroutineScope
+ import androidx.compose.runtime.setValue
++import androidx.compose.ui.Alignment
+ import androidx.compose.ui.Modifier
++import androidx.compose.ui.draw.clip
++import androidx.compose.ui.graphics.Color
+ import androidx.compose.ui.platform.LocalConfiguration
+ import androidx.compose.ui.platform.LocalContext
+ import androidx.compose.ui.platform.LocalInspectionMode
+ import androidx.compose.ui.res.stringArrayResource
+ import androidx.compose.ui.res.stringResource
+-import androidx.compose.ui.tooling.preview.Preview
++import androidx.compose.ui.text.font.FontWeight
+ import androidx.compose.ui.unit.dp
+ import androidx.compose.ui.unit.sp
+ import androidx.navigation.NavController
+-import androidx.navigation.compose.rememberNavController
+-import com.afkanerd.smswithoutborders_libsmsmms.extensions.context.getActivity
+ import com.afkanerd.smswithoutborders_libsmsmms.extensions.context.getCurrentLocale
+ import com.afkanerd.smswithoutborders_libsmsmms.extensions.context.setLocale
+ import com.afkanerd.smswithoutborders_libsmsmms.ui.SettingsItem
+@@ -63,14 +70,57 @@ import com.example.sw0b_001.extensions.context.settingsGetStoreTokensOnDevice
+ import com.example.sw0b_001.extensions.context.settingsGetUseDeviceId
+ import com.example.sw0b_001.extensions.context.settingsSetIsLoggedIn
+ import com.example.sw0b_001.extensions.context.settingsSetLockDownApp
+-import com.example.sw0b_001.extensions.context.settingsSetUseDeviceId
+-import com.example.sw0b_001.ui.theme.AppTheme
+ import com.example.sw0b_001.ui.viewModels.TokensViewModel
+ import io.grpc.StatusRuntimeException
+-import kotlinx.coroutines.CoroutineScope
+ import kotlinx.coroutines.Dispatchers
+ import kotlinx.coroutines.launch
+ 
++@Composable
++private fun SectionLabel(text: String) {
++    Row(
++        verticalAlignment = Alignment.CenterVertically,
++        modifier = Modifier.padding(start = 20.dp, top = 20.dp, bottom = 8.dp)
++    ) {
++        Box(
++            modifier = Modifier
++                .size(6.dp)
++                .clip(CircleShape)
++                .background(MaterialTheme.colorScheme.primary)
++        )
++        Spacer(modifier = Modifier.width(8.dp))
++        Text(
++            text = text.uppercase(),
++            style = MaterialTheme.typography.labelMedium.copy(
++                fontWeight = FontWeight.SemiBold,
++                letterSpacing = 1.2.sp
++            ),
++            color = MaterialTheme.colorScheme.primary
++        )
++    }
++}
++
++@Composable
++private fun RowIcon(
++    icon: androidx.compose.ui.graphics.vector.ImageVector,
++    tint: Color = MaterialTheme.colorScheme.onSurfaceVariant,
++    background: Color = MaterialTheme.colorScheme.surfaceContainerHighest
++) {
++    Box(
++        modifier = Modifier
++            .size(40.dp)
++            .clip(CircleShape)
++            .background(background),
++        contentAlignment = Alignment.Center
++    ) {
++        Icon(
++            imageVector = icon,
++            contentDescription = null,
++            tint = tint,
++            modifier = Modifier.size(20.dp)
++        )
++    }
++}
++
+ @OptIn(ExperimentalMaterial3Api::class)
+ @Composable
+ fun SettingsView(
+@@ -97,7 +147,6 @@ fun SettingsView(
+ 
+     var isLoading by remember { mutableStateOf(false) }
+ 
+-
+     val localeArraysValues = stringArrayResource(R.array.language_values)
+     val localeArraysOptions= stringArrayResource(R.array.language_options)
+ 
+@@ -115,7 +164,12 @@ fun SettingsView(
+                     }
+                 },
+                 title = {
+-                    Text(stringResource(R.string.general_settings))
++                    Text(
++                        stringResource(R.string.general_settings),
++                        style = MaterialTheme.typography.titleLarge.copy(
++                            fontWeight = FontWeight.Bold
++                        )
++                    )
+                 },
+                 colors = TopAppBarDefaults.topAppBarColors()
+             )
+@@ -128,22 +182,52 @@ fun SettingsView(
+             if(isLoading || inPreviewMode)
+                 LinearProgressIndicator(Modifier.fillMaxWidth())
+ 
+-            Spacer(modifier = Modifier.height(4.dp))
+-            Text(
+-                stringResource(R.string.system),
+-                fontSize = 13.sp,
+-                modifier = Modifier.padding(start = 10.dp),
+-                style = MaterialTheme.typography.labelSmall,
+-                color = MaterialTheme.colorScheme.secondary,
+-            )
+-            SettingsItem(
+-                itemTitle = stringResource(R.string.language),
+-                itemDescription = context.getCurrentLocale()?.displayName ?:
+-                stringResource(R.string.english1),
+-                checked = null,
+-                enabled = !isLoading,
++            SectionLabel(stringResource(R.string.system))
++
++            Surface(
++                shape = RoundedCornerShape(20.dp),
++                color = Color.Transparent,
++                modifier = Modifier
++                    .fillMaxWidth()
++                    .padding(horizontal = 16.dp)
+             ) {
+-                localeExpanded = true
++                Column {
++                    Row(verticalAlignment = Alignment.CenterVertically) {
++                        Spacer(modifier = Modifier.width(12.dp))
++                        RowIcon(icon = Icons.Filled.Language)
++                        Box(modifier = Modifier.weight(1f)) {
++                            SettingsItem(
++                                itemTitle = stringResource(R.string.language),
++                                itemDescription = context.getCurrentLocale()?.displayName ?:
++                                stringResource(R.string.english1),
++                                checked = null,
++                                enabled = !isLoading,
++                            ) {
++                                localeExpanded = true
++                            }
++                        }
++                    }
++
++                    Row(verticalAlignment = Alignment.CenterVertically) {
++                        Spacer(modifier = Modifier.width(12.dp))
++                        RowIcon(icon = Icons.Filled.Palette)
++                        Box(modifier = Modifier.weight(1f)) {
++                            SettingsItem(
++                                itemTitle = stringResource(com.afkanerd.lib_smsmms_android.R.string.theme),
++                                itemDescription = when(currentNightMode) {
++                                    Configuration.UI_MODE_NIGHT_YES -> stringResource(com.afkanerd.lib_smsmms_android.R.string.dark)
++                                    Configuration.UI_MODE_NIGHT_NO -> stringResource(com.afkanerd.lib_smsmms_android.R.string.light)
++                                    else -> stringResource(com.afkanerd.lib_smsmms_android.R.string.system_default)
++                                },
++                                checked = null,
++                                enabled = !isLoading,
++                                horizontalDivide = false
++                            ) {
++                                themeExpanded = true
++                            }
++                        }
++                    }
++                }
+             }
+ 
+             Column(
+@@ -153,7 +237,10 @@ fun SettingsView(
+             ) {
+                 DropdownMenu(
+                     expanded = localeExpanded,
+-                    onDismissRequest = { localeExpanded = false }
++                    onDismissRequest = { localeExpanded = false },
++                    modifier = Modifier
++                        .clip(RoundedCornerShape(16.dp))
++                        .background(MaterialTheme.colorScheme.surfaceContainerHigh)
+                 ) {
+                     localeArraysOptions.forEachIndexed { i, item ->
+                         DropdownMenuItem(
+@@ -167,19 +254,6 @@ fun SettingsView(
+                 }
+             }
+ 
+-            SettingsItem(
+-                itemTitle = stringResource(com.afkanerd.lib_smsmms_android.R.string.theme),
+-                itemDescription = when(currentNightMode) {
+-                    Configuration.UI_MODE_NIGHT_YES -> stringResource(com.afkanerd.lib_smsmms_android.R.string.dark)
+-                    Configuration.UI_MODE_NIGHT_NO -> stringResource(com.afkanerd.lib_smsmms_android.R.string.light)
+-                    else -> stringResource(com.afkanerd.lib_smsmms_android.R.string.system_default)
+-                },
+-                checked = null,
+-                enabled = !isLoading,
+-            ) {
+-                themeExpanded = true
+-            }
+-
+             Column(
+                 modifier = Modifier
+                     .fillMaxWidth()
+@@ -187,7 +261,10 @@ fun SettingsView(
+             ) {
+                 DropdownMenu(
+                     expanded = themeExpanded,
+-                    onDismissRequest = { themeExpanded = false }
++                    onDismissRequest = { themeExpanded = false },
++                    modifier = Modifier
++                        .clip(RoundedCornerShape(16.dp))
++                        .background(MaterialTheme.colorScheme.surfaceContainerHigh)
+                 ) {
+                     DropdownMenuItem(
+                         text = { Text(stringResource(com.afkanerd.lib_smsmms_android.R.string.light)) },
+@@ -216,17 +293,6 @@ fun SettingsView(
+                 }
+             }
+ 
+-//            HorizontalDivider(Modifier.padding(8.dp))
+-
+-            Spacer(Modifier.padding(8.dp))
+-            Text(
+-                stringResource(R.string.publishing),
+-                fontSize = 13.sp,
+-                modifier = Modifier.padding(start = 12.dp),
+-                style = MaterialTheme.typography.labelSmall,
+-                color = MaterialTheme.colorScheme.secondary,
+-            )
+-
+ //            SettingsItem(
+ //                itemTitle = stringResource(R.string.send_messages_with_device_id),
+ //                itemDescription = stringResource(R.string.device_id_lets_you_send_messages_without_using_your_actual_phone_number_for_authentication_this_works_well_for_dual_sim_phones),
+@@ -237,73 +303,103 @@ fun SettingsView(
+ //                useDeviceId = it ?: true
+ //            }
+ 
+-            Spacer(Modifier.padding(8.dp))
+-
+-            Text(
+-                stringResource(R.string.security),
+-                fontSize = 13.sp,
+-                modifier = Modifier.padding(start = 12.dp),
+-                style = MaterialTheme.typography.labelSmall,
+-                color = MaterialTheme.colorScheme.secondary,
+-            )
++            SectionLabel(stringResource(R.string.security))
+ 
+-            SettingsItem(
+-                itemTitle = stringResource(R.string.lock_app),
+-                itemDescription = stringResource(R.string.this_will_lock_the_app_using_your_phone_s_biometric_security_configurations_you_will_need_to_globally_set_for_the_device),
+-                checked = setLockDownApp,
+-                enabled = !isLoading,
+-                horizontalDivide = false
+-            ) { checked ->
+-                context.promptBiometrics(context.getAppCompatActivity()!!) {
+-                    if(it) {
+-                        context.settingsSetLockDownApp(checked!!)
+-                        setLockDownApp = checked
+-                    }
+-                    else {
+-                        scope.launch(Dispatchers.Default) {
+-                            Toast.makeText(context,
+-                                context.getString(R.string.failed_to_set_biometric_authentication),
+-                                Toast.LENGTH_LONG).show()
++            Surface(
++                shape = RoundedCornerShape(20.dp),
++                color = Color.Transparent,
++                modifier = Modifier
++                    .fillMaxWidth()
++                    .padding(horizontal = 16.dp)
++            ) {
++                Row(verticalAlignment = Alignment.CenterVertically) {
++                    Spacer(modifier = Modifier.width(12.dp))
++                    RowIcon(icon = Icons.Filled.Fingerprint)
++                    Box(modifier = Modifier.weight(1f)) {
++                        SettingsItem(
++                            itemTitle = stringResource(R.string.lock_app),
++                            itemDescription = stringResource(R.string.this_will_lock_the_app_using_your_phone_s_biometric_security_configurations_you_will_need_to_globally_set_for_the_device),
++                            checked = setLockDownApp,
++                            enabled = !isLoading,
++                            horizontalDivide = false
++                        ) { checked ->
++                            context.promptBiometrics(context.getAppCompatActivity()!!) {
++                                if(it) {
++                                    context.settingsSetLockDownApp(checked!!)
++                                    setLockDownApp = checked
++                                }
++                                else {
++                                    scope.launch(Dispatchers.Default) {
++                                        Toast.makeText(context,
++                                            context.getString(R.string.failed_to_set_biometric_authentication),
++                                            Toast.LENGTH_LONG).show()
++                                    }
++                                }
++                            }
+                         }
+                     }
+                 }
+             }
+ 
+-            SettingsItem(
+-                itemTitle = stringResource(R.string.delete_account),
+-                itemDescription = stringResource(R.string.this_would_revoke_all_your_stored_tokens_security_keys_and_every_data_you_have_stored_on_device_and_vault_you_can_still_use_bridges_whenever_you_prefer),
+-                isWarning = true,
+-                enabled = !isLoading,
++            SectionLabel(stringResource(R.string.account))
++
++            Surface(
++                shape = RoundedCornerShape(20.dp),
++                color = MaterialTheme.colorScheme.error,
++                modifier = Modifier
++                    .fillMaxWidth()
++                    .padding(horizontal = 16.dp)
++                    .clip(RoundedCornerShape(20.dp))
+             ) {
+-                isLoading = true
+-                scope.launch(Dispatchers.Default) {
+-                    context.settingsSetIsLoggedIn(false)
+-                    try {
+-                        TODO("Remove from cloud")
+-                        tokensViewModel.reset {
+-                            navController.popBackStack()
+-                        }
+-                    } catch(e: StatusRuntimeException) {
+-                        e.printStackTrace()
+-                        scope.launch(Dispatchers.Main){
+-                            Toast.makeText(context, e.status.description,
+-                                Toast.LENGTH_SHORT)
+-                                .show()
+-                        }
+-                    } catch(e: Exception) {
+-                        e.printStackTrace()
+-                        scope.launch(Dispatchers.Main){
+-                            Toast.makeText(context, e.message,
+-                                Toast.LENGTH_SHORT).show()
++                Row(verticalAlignment = Alignment.CenterVertically) {
++                    Spacer(modifier = Modifier.width(12.dp))
++                    RowIcon(
++                        icon = Icons.Filled.Delete,
++                        tint = MaterialTheme.colorScheme.error,
++                        background = Color.White
++                    )
++                    Box(modifier = Modifier.weight(1f)) {
++                        SettingsItem(
++                            itemTitle = stringResource(R.string.delete_account),
++                            itemDescription = stringResource(R.string.this_would_revoke_all_your_stored_tokens_security_keys_and_every_data_you_have_stored_on_device_and_vault_you_can_still_use_bridges_whenever_you_prefer),
++                            isWarning = true,
++                            enabled = !isLoading,
++                        ) {
++                            isLoading = true
++                            scope.launch(Dispatchers.Default) {
++                                context.settingsSetIsLoggedIn(false)
++                                try {
++                                    TODO("Remove from cloud")
++                                    tokensViewModel.reset {
++                                        navController.popBackStack()
++                                    }
++                                } catch(e: StatusRuntimeException) {
++                                    e.printStackTrace()
++                                    scope.launch(Dispatchers.Main){
++                                        Toast.makeText(context, e.status.description,
++                                            Toast.LENGTH_SHORT)
++                                            .show()
++                                    }
++                                } catch(e: Exception) {
++                                    e.printStackTrace()
++                                    scope.launch(Dispatchers.Main){
++                                        Toast.makeText(context, e.message,
++                                            Toast.LENGTH_SHORT).show()
++                                    }
++                                } finally {
++                                    isLoading = false
++                                }
++                            }
+                         }
+-                    } finally {
+-                        isLoading = false
+                     }
+                 }
+             }
+ 
++            Spacer(modifier = Modifier.height(24.dp))
++
+             if(BuildConfig.DEBUG) {
+-                HorizontalDivider(Modifier.padding(top = 20.dp))
++                HorizontalDivider(Modifier.padding(horizontal = 16.dp))
++                Spacer(modifier = Modifier.height(4.dp))
+                 SettingsItem(
+                     itemTitle = "Export logs",
+                     itemDescription = "Export crash logs for debugging purposes",
+@@ -312,6 +408,8 @@ fun SettingsView(
+                     CrashHandler.offerCrashLogOptions(activity, context)
+                 }
+             }
++
++            Spacer(modifier = Modifier.height(24.dp))
+         }
+     }
+-}
++}
+\ No newline at end of file


### PR DESCRIPTION
changes i made to the setting page,  I put things into groups with rounded boxes and gave each one a little picture next to it. I didn't change how anything actually works, just how it looks.

- Language and Theme are now grouped together under a "System" label, with a globe icon and a paint palette icon
- Lock app is under a "Security" label, with a fingerprint icon
- Delete account is under an "Account" label. It used to be one plain red bar across the whole screen, now it's a red rounded box with a white circle and a trash can icon inside

# Notes
I only changed how it looks, nothing about how it works. I checked my code changes carefully before sending this in, to make sure I didn't accidentally break anything using git diff.